### PR TITLE
Added a resque-ctl binary

### DIFF
--- a/lib/resque/master.rb
+++ b/lib/resque/master.rb
@@ -74,7 +74,9 @@ module Resque
     end
 
     def run
-      eval(File.read(@config_path), binding)
+      self.instance_eval(File.read(@config_path), @config_path, 0)
+    rescue => e
+      raise "Config error: '#{e.message}' at #{e.backtrace[0].gsub(/:in `run'/,'')}"
     end
 
     def self.setup(options)

--- a/lib/resque/master.rb
+++ b/lib/resque/master.rb
@@ -81,7 +81,6 @@ module Resque
       options[:runpath] = Dir.pwd if options[:runpath].nil?
 
       Resque.setup do |forker|
-        puts "calling Resque setup: #{options.inspect}"
         if options[:preload_app]
           begin
             $:.unshift options[:runpath] # Makes 1.9.2 happy
@@ -96,7 +95,6 @@ module Resque
         end
 
         File.open(options[:pidfile],"wb") {|f| f << Process.pid } if options[:pidfile]
-        puts options.inspect
         forker.workload = options[:worker_queues] * options[:worker_processes].to_i if options[:worker_queues] && options[:worker_processes]
         forker.options.interval = options[:work_interval].to_i if options.key?(:work_interval)
       end


### PR DESCRIPTION
I think this might make it easier for people.  It makes deploying workers more like deploying a unicorn app.

I didn't use Process.daemon - since it's not in 1.8.x... Also, having a little bit more control over how the process demonizes allows for finer grained error reporting... 
